### PR TITLE
Improve Notion-like layout

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,11 +1,12 @@
 import { LoginForm } from "@/components/login-form";
+import { PageContainer } from "@/components/ui/page-container";
 
 export default function LoginPage() {
   return (
     <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
-      <div className="flex w-full max-w-sm flex-col gap-6">
+      <PageContainer className="max-w-sm">
         <LoginForm />
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/src/app/dashboard/mentions/[topicId]/page.tsx
+++ b/src/app/dashboard/mentions/[topicId]/page.tsx
@@ -3,6 +3,7 @@ import {
   MentionsToolbar,
   MentionsTable,
 } from "@/components/dashboard";
+import { PageContainer } from "@/components/ui/page-container";
 
 export default async function Page({
   params,
@@ -12,12 +13,10 @@ export default async function Page({
   const { topicId } = await params;
 
   return (
-    <>
+    <PageContainer className="flex flex-1 flex-col gap-4">
       <MentionsBreadcrumb topicId={topicId} />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <MentionsToolbar topicId={topicId} />
-        <MentionsTable topicId={topicId} />
-      </div>
-    </>
+      <MentionsToolbar topicId={topicId} />
+      <MentionsTable topicId={topicId} />
+    </PageContainer>
   );
 }

--- a/src/app/dashboard/rankings/[topicId]/[promptId]/results/page.tsx
+++ b/src/app/dashboard/rankings/[topicId]/[promptId]/results/page.tsx
@@ -4,6 +4,7 @@ import {
   ResultsLoadingSkeleton,
   ResultsContent,
 } from "@/components/dashboard";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface ResultsPageProps {
   params: Promise<{ topicId: string; promptId: string }>;
@@ -13,13 +14,11 @@ export default async function ResultsPage({ params }: ResultsPageProps) {
   const { promptId, topicId } = await params;
 
   return (
-    <>
+    <PageContainer className="flex flex-1 flex-col gap-4">
       <RankingsBreadcrumb topicId={topicId} page="results" />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <Suspense fallback={<ResultsLoadingSkeleton />}>
-          <ResultsContent promptId={promptId} />
-        </Suspense>
-      </div>
-    </>
+      <Suspense fallback={<ResultsLoadingSkeleton />}>
+        <ResultsContent promptId={promptId} />
+      </Suspense>
+    </PageContainer>
   );
 }

--- a/src/app/dashboard/rankings/[topicId]/page.tsx
+++ b/src/app/dashboard/rankings/[topicId]/page.tsx
@@ -3,6 +3,7 @@ import {
   PromptToolbar,
   PromptsTable,
 } from "@/components/dashboard";
+import { PageContainer } from "@/components/ui/page-container";
 
 export default async function Page({
   params,
@@ -12,12 +13,10 @@ export default async function Page({
   const { topicId } = await params;
 
   return (
-    <>
+    <PageContainer className="flex flex-1 flex-col gap-4">
       <RankingsBreadcrumb topicId={topicId} page="rankings" />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <PromptToolbar topicId={topicId} />
-        <PromptsTable topicId={topicId} />
-      </div>
-    </>
+      <PromptToolbar topicId={topicId} />
+      <PromptsTable topicId={topicId} />
+    </PageContainer>
   );
 }

--- a/src/app/dashboard/topics/[topicId]/page.tsx
+++ b/src/app/dashboard/topics/[topicId]/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { DashboardOverview } from "@/components/dashboard/main/overview";
 import { DashboardBreadcrumb } from "@/components/dashboard/main/breadcrumb";
 import { DashboardOverviewSkeleton } from "@/components/dashboard/main/skeleton";
+import { PageContainer } from "@/components/ui/page-container";
 
 export default async function DashboardTopicPage({
   params,
@@ -10,13 +11,13 @@ export default async function DashboardTopicPage({
 }) {
   const { topicId } = await params;
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+    <PageContainer className="flex flex-1 flex-col gap-4">
       <DashboardBreadcrumb topicId={topicId} />
       <div className="min-h-[100vh] flex-1 rounded-xl md:min-h-min">
         <Suspense fallback={<DashboardOverviewSkeleton />}>
           <DashboardOverview topicId={topicId} />
         </Suspense>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/app/dashboard/topics/page.tsx
+++ b/src/app/dashboard/topics/page.tsx
@@ -3,15 +3,14 @@ import {
   TopicsToolbar,
   TopicsBreadcrumb,
 } from "@/components/dashboard";
+import { PageContainer } from "@/components/ui/page-container";
 
 export default function Page() {
   return (
-    <>
+    <PageContainer className="flex flex-1 flex-col gap-4">
       <TopicsBreadcrumb />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <TopicsToolbar />
-        <TopicsTable />
-      </div>
-    </>
+      <TopicsToolbar />
+      <TopicsTable />
+    </PageContainer>
   );
 }

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -5,6 +5,7 @@ import { PromptStep } from "./prompt-step";
 import { AnalysisStep } from "./analysis-step";
 import { CheckCircle2, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PageContainer } from "@/components/ui/page-container";
 import { redirect } from "next/navigation";
 
 interface Step {
@@ -73,7 +74,7 @@ export async function Onboarding({ searchParams }: OnboardingProps) {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
-      <div className="container max-w-4xl mx-auto py-12 px-4">
+      <PageContainer className="py-12">
         <div className="space-y-8">
           <StepContainer step={steps[0]} isLastStep={false}>
             <TopicStep />
@@ -87,7 +88,7 @@ export async function Onboarding({ searchParams }: OnboardingProps) {
             {firstPromptId && <AnalysisStep promptId={firstPromptId} />}
           </StepContainer>
         </div>
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/src/components/ui/page-container.tsx
+++ b/src/components/ui/page-container.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export function PageContainer({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-3xl px-4 py-6 md:px-6 md:py-8",
+        className
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `PageContainer` component for consistent Notion‑style width
- update onboarding flow and dashboard pages to use `PageContainer`
- center the sign‑in form using `PageContainer`

## Testing
- `bun run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a63f53388327bb770714d9e054c8
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a PageContainer component to give pages a consistent Notion-like width and layout. Updated the onboarding flow, dashboard pages, and sign-in form to use this new container.

<!-- End of auto-generated description by cubic. -->

