### PR TITLE
Add account management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Visit `http://localhost:3000` to start tracking your AI search rankings.
 | **Competitive Analysis**  | Monitor multiple brands in the same queries          |
 | **Export & Reporting**    | Generate CSV/PDF reports for stakeholders            |
 | **API Access**            | Full programmatic control via REST endpoints         |
+| **Account Management**    | Built-in page to view usage and manage billing |
 
 ## Architecture
 

--- a/src/app/dashboard/account/page.tsx
+++ b/src/app/dashboard/account/page.tsx
@@ -1,0 +1,15 @@
+import { AccountBreadcrumb, AccountSummary } from "@/components/dashboard";
+import { UsageBanner } from "@/components/usage-banner";
+
+export default function Page() {
+  return (
+    <>
+      <AccountBreadcrumb />
+      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        {/* Usage banner displays current usage and upgrade prompts */}
+        <UsageBanner />
+        <AccountSummary />
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/account/breadcrumb.tsx
+++ b/src/components/dashboard/account/breadcrumb.tsx
@@ -1,0 +1,21 @@
+import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+export function AccountBreadcrumb() {
+  return (
+    <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+      <div className="flex items-center gap-2 px-4">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Account</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+    </header>
+  );
+}

--- a/src/components/dashboard/account/summary.tsx
+++ b/src/components/dashboard/account/summary.tsx
@@ -1,0 +1,31 @@
+import { getUser } from "@/auth/server";
+import { manageSubscription } from "@/app/actions/stripe";
+import { getUserPlan, checkUsageLimit } from "@/lib/subscription";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+export async function AccountSummary() {
+  const user = await getUser();
+  if (!user) return null;
+
+  const plan = await getUserPlan();
+  const usage = await checkUsageLimit(user.id);
+
+  return (
+    <div className="space-y-4 p-4">
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Subscription</h2>
+        <Badge variant="outline" className="mr-2">
+          {plan.plan}
+        </Badge>
+        <span className="text-sm text-muted-foreground">Status: {plan.planStatus}</span>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        Usage: {usage.currentUsage}/{usage.limit} prompts this month
+      </div>
+      <form action={manageSubscription}>
+        <Button type="submit" variant="outline">Manage Subscription</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -19,6 +19,9 @@ export { MentionsBreadcrumb } from "./mentions/breadcrumb";
 export { SuggestionsDialog } from "./rankings/suggestions-dialog";
 export { SuggestionsList } from "./rankings/suggestions-dialog";
 
+export { AccountBreadcrumb } from "./account/breadcrumb";
+export { AccountSummary } from "./account/summary";
+
 // Server actions - import directly when needed:
 // - "./topics/actions" for topic server actions
 // - "./rankings/actions" for prompt server actions

--- a/src/components/sidebar/nav/main.tsx
+++ b/src/components/sidebar/nav/main.tsx
@@ -1,4 +1,4 @@
-import { AtSign, BicepsFlexed, Bot, Tag } from "lucide-react";
+import { AtSign, BicepsFlexed, Bot, Tag, Settings } from "lucide-react";
 
 import {
   SidebarGroup,
@@ -25,6 +25,11 @@ const staticNavMain = [
     title: "Mentions",
     icon: AtSign,
     url: "/dashboard/mentions",
+  },
+  {
+    title: "Account",
+    icon: Settings,
+    url: "/dashboard/account",
   },
   {
     title: "Competitors",

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -13,7 +13,7 @@ export interface UserSubscription {
   limits: (typeof PLANS)[PlanType]["limits"];
 }
 
-const getUserPlan = async (): Promise<UserSubscription> => {
+export const getUserPlan = async (): Promise<UserSubscription> => {
   const user = await getUser();
   const plan = user?.plan && isPlanType(user.plan) ? user.plan : "free";
   const subDetails = PLANS[plan] ?? PLANS.free;


### PR DESCRIPTION
## Summary
- add export for `getUserPlan`
- add new Account page with summary and breadcrumb
- link Account page in sidebar navigation
- mention account management feature in README

## Testing
- `bun run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a625af3c832780055fb3b9964dcc