### PR TITLE
Fix mention cleanup in background processing

### DIFF
--- a/src/lib/background/mentions.ts
+++ b/src/lib/background/mentions.ts
@@ -134,6 +134,11 @@ export async function processUserMentions(userId: string, topicId?: string) {
         return { success: true, processed: 0, mentionsFound: 0 };
       }
 
+      // Clear out any existing mentions for the prompts before processing
+      await tx
+        .delete(mentions)
+        .where(inArray(mentions.promptId, promptIds));
+
       const queue = new PQueue({
         concurrency: PARALLEL_BATCHES,
         interval: 1000,
@@ -199,9 +204,7 @@ export async function processUserMentions(userId: string, topicId?: string) {
                 }
               }
 
-              await tx
-                .delete(mentions)
-                .where(inArray(mentions.promptId, promptIds));
+
 
               const INSERT_CHUNK_SIZE = 100;
               for (


### PR DESCRIPTION
## Summary
- remove redundant mention deletions in each batch
- clear existing mentions a single time before batch processing begins

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a89cbe1483279c3d56033d986623
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up mention deletion logic by removing repeated deletions in each batch and clearing existing mentions once before processing starts.

<!-- End of auto-generated description by cubic. -->

