### PR TITLE
Handle inactive subscription usage

### DIFF
--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -51,7 +51,7 @@ export async function checkUsageLimit(userId: string): Promise<{
     return {
       canProcess: false,
       currentUsage: 0,
-      limit: userPlan.limits.promptsPerDay,
+      limit: -1,
       plan: userPlan.plan,
     };
   }


### PR DESCRIPTION
## Summary
- return `-1` as usage limit when subscription is inactive
- detect `-1` limit in prompts API route and show inactive subscription message

## Testing
- `bun run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a8c8af2c83279f44bdf0fd00816c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Returns -1 as the usage limit when a subscription is inactive, and updates the prompts API to show an inactive subscription message when this is detected.

<!-- End of auto-generated description by cubic. -->

