### PR TITLE
Improve mention analysis API logic

### DIFF
--- a/src/lib/background/mentions.ts
+++ b/src/lib/background/mentions.ts
@@ -71,7 +71,7 @@ type MentionInsert = {
   competitorName?: string | null;
 };
 
-async function acquireProcessingLock(
+export async function acquireProcessingLock(
   userId: string,
   topicId?: string
 ): Promise<boolean> {


### PR DESCRIPTION
## Summary
- export `acquireProcessingLock` helper
- validate topicId and check active processing in mention analysis API

## Testing
- `bun run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b117aeac8327b04a00a75f6d4280
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the mention analysis API to validate topic IDs and prevent duplicate processing for the same user and topic.

- **Bug Fixes**
  - Added a check to require topicId in API requests.
  - Blocked new analysis if one is already running for the same user and topic.

<!-- End of auto-generated description by cubic. -->

