### PR TITLE
Add toast notification for login errors

### DIFF
--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -13,6 +13,7 @@ import { signIn } from "@/auth/client";
 import { useState } from "react";
 import { GoogleIcon } from "@/components/ui/icons";
 import Image from "next/image";
+import { toast } from "sonner";
 
 export function LoginForm({
   className,
@@ -29,6 +30,7 @@ export function LoginForm({
       });
     } catch (error) {
       console.error(error);
+      toast.error("Failed to sign in. Please try again.");
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- show toast notification when sign in fails

## Testing
- `bun run lint` *(skipped lint)*

------
https://chatgpt.com/codex/tasks/task_e_6855b3def9408327883c1ab5d3ca77b9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a toast notification to show an error message when sign in fails.

<!-- End of auto-generated description by cubic. -->

