### PR TITLE
Improve login error handling and add policy pages

### DIFF
--- a/src/app/(auth)/signin/layout.tsx
+++ b/src/app/(auth)/signin/layout.tsx
@@ -1,0 +1,14 @@
+import { Toaster } from "@/components/ui/sonner";
+
+export default function SignInLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <div className="flex-1">{children}</div>
+      <Toaster />
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,8 @@
+export default function PrivacyPage() {
+  return (
+    <div className="p-6 md:p-10 max-w-3xl mx-auto">
+      <h1 className="text-xl font-bold mb-4">Privacy Policy</h1>
+      <p>Our privacy policy will be published here soon.</p>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,8 @@
+export default function TermsPage() {
+  return (
+    <div className="p-6 md:p-10 max-w-3xl mx-auto">
+      <h1 className="text-xl font-bold mb-4">Terms of Service</h1>
+      <p>Our full terms of service will be published here soon.</p>
+    </div>
+  );
+}

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -13,6 +13,7 @@ import { signIn } from "@/auth/client";
 import { useState } from "react";
 import { GoogleIcon } from "@/components/ui/icons";
 import Image from "next/image";
+import { toast } from "sonner";
 
 export function LoginForm({
   className,
@@ -29,6 +30,7 @@ export function LoginForm({
       });
     } catch (error) {
       console.error(error);
+      toast.error("Failed to sign in. Please try again.");
     } finally {
       setIsLoading(false);
     }
@@ -69,8 +71,8 @@ export function LoginForm({
         </CardContent>
       </Card>
       <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
-        By clicking continue, you agree to our <a href="#">Terms of Service</a>{" "}
-        and <a href="#">Privacy Policy</a>.
+        By clicking continue, you agree to our <a href="/terms">Terms of Service</a>{" "}
+        and <a href="/privacy">Privacy Policy</a>.
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show toast error on failed login
- link to Terms and Privacy pages in login form
- add Toaster layout for sign in page
- add placeholder Terms of Service and Privacy Policy pages

## Testing
- `bun run lint` *(fails: Skipping lint)*
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6855b3089d3c8327b996e8a408f8d30b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved login error handling by showing a toast on failed sign-in and added links to Terms of Service and Privacy Policy pages in the login form.

- **New Features**
  - Added placeholder Terms of Service and Privacy Policy pages.
  - Added a Toaster layout to the sign-in page for error messages.

<!-- End of auto-generated description by cubic. -->

