### PR TITLE
Fix Promise-typed params in Next.js pages

### DIFF
--- a/src/app/api/prompts/[promptId]/status/route.ts
+++ b/src/app/api/prompts/[promptId]/status/route.ts
@@ -5,10 +5,10 @@ import { eq } from "drizzle-orm";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ promptId: string }> }
+  { params }: { params: { promptId: string } }
 ) {
   try {
-    const { promptId } = await params;
+    const { promptId } = params;
 
     if (!promptId) {
       return NextResponse.json(

--- a/src/app/dashboard/mentions/[topicId]/page.tsx
+++ b/src/app/dashboard/mentions/[topicId]/page.tsx
@@ -8,9 +8,9 @@ import { PageContainer } from "@/components/ui/page-container";
 export default async function Page({
   params,
 }: {
-  params: Promise<{ topicId?: string }>;
+  params: { topicId?: string };
 }) {
-  const { topicId } = await params;
+  const { topicId } = params;
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,10 @@
 import { Onboarding } from "@/components/onboarding";
 
 interface PageProps {
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+  searchParams: { [key: string]: string | string[] | undefined };
 }
 
 export default async function Page({ searchParams }: PageProps) {
-  const params = await searchParams;
+  const params = searchParams;
   return <Onboarding searchParams={params} />;
 }

--- a/src/app/dashboard/rankings/[topicId]/[promptId]/results/page.tsx
+++ b/src/app/dashboard/rankings/[topicId]/[promptId]/results/page.tsx
@@ -7,11 +7,11 @@ import {
 import { PageContainer } from "@/components/ui/page-container";
 
 interface ResultsPageProps {
-  params: Promise<{ topicId: string; promptId: string }>;
+  params: { topicId: string; promptId: string };
 }
 
 export default async function ResultsPage({ params }: ResultsPageProps) {
-  const { promptId, topicId } = await params;
+  const { promptId, topicId } = params;
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4">

--- a/src/app/dashboard/rankings/[topicId]/page.tsx
+++ b/src/app/dashboard/rankings/[topicId]/page.tsx
@@ -8,9 +8,9 @@ import { PageContainer } from "@/components/ui/page-container";
 export default async function Page({
   params,
 }: {
-  params: Promise<{ topicId?: string }>;
+  params: { topicId?: string };
 }) {
-  const { topicId } = await params;
+  const { topicId } = params;
 
   return (
     <PageContainer className="flex flex-1 flex-col gap-4">

--- a/src/app/dashboard/topics/[topicId]/page.tsx
+++ b/src/app/dashboard/topics/[topicId]/page.tsx
@@ -7,9 +7,9 @@ import { PageContainer } from "@/components/ui/page-container";
 export default async function DashboardTopicPage({
   params,
 }: {
-  params: Promise<{ topicId: string }>;
+  params: { topicId: string };
 }) {
-  const { topicId } = await params;
+  const { topicId } = params;
   return (
     <PageContainer className="flex flex-1 flex-col gap-4">
       <DashboardBreadcrumb topicId={topicId} />

--- a/src/app/stripe-result/page.tsx
+++ b/src/app/stripe-result/page.tsx
@@ -1,11 +1,11 @@
 import { StripeResult } from "@/components/stripe-result";
 
 interface PageProps {
-  searchParams: Promise<{ success: string; canceled: string }>;
+  searchParams: { success: string; canceled: string };
 }
 
 export default async function Page({ searchParams }: PageProps) {
-  const params = await searchParams;
+  const params = searchParams;
   const success = params.success === "true";
   const canceled = params.canceled === "true";
 


### PR DESCRIPTION
## Summary
- treat `params` and `searchParams` as synchronous objects
- update status API and dashboard pages accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855b7101ca883279e1eb5fba852d0dc