### PR TITLE
Fix pagination query ordering

### DIFF
--- a/src/lib/background/mentions.ts
+++ b/src/lib/background/mentions.ts
@@ -7,7 +7,7 @@
 
 import { db } from "@/db";
 import { mentions, modelResults, prompts } from "@/db/schema";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql, asc } from "drizzle-orm";
 import { generateObject } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
@@ -183,6 +183,7 @@ export async function processUserMentions(userId: string, topicId?: string) {
                 with: {
                   prompt: { with: { topic: true } },
                 },
+                orderBy: asc(modelResults.createdAt),
                 limit: BATCH_SIZE,
                 offset: offset,
               });


### PR DESCRIPTION
## Summary
- ensure paginated model results are sorted by creation date

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6855b75892b8832798063938d44d37d8
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed pagination to always return model results sorted by creation date.

<!-- End of auto-generated description by cubic. -->

